### PR TITLE
Version can specified when projecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ end
 
 ## Project Into an Entity
 ```ruby
+# Project all events in the stream starting from some_version
 entity = SomeEntity.new
 SomeProjection.(entity, stream_name, starting_position: some_version)
+
+# Project all events in the stream starting from some_version and ending at ending_version
+entity = SomeEntity.new
+SomeProjection.(entity, stream_name, starting_position, some_version, ending_position: ending_version)
 ```
 
 ## License

--- a/lib/event_store/entity_projection/controls/message.rb
+++ b/lib/event_store/entity_projection/controls/message.rb
@@ -26,7 +26,9 @@ module EventStore
           time || ::Controls::Time.reference
         end
 
-        def self.example
+        def self.example(attribute=nil)
+          attribute ||= self.attribute
+
           msg = SomeMessage.new
           msg.some_attribute = attribute
           msg

--- a/lib/event_store/entity_projection/controls/message.rb
+++ b/lib/event_store/entity_projection/controls/message.rb
@@ -26,11 +26,11 @@ module EventStore
           time || ::Controls::Time.reference
         end
 
-        def self.example(attribute=nil)
-          attribute ||= self.attribute
+        def self.example(attribute_value=nil)
+          attribute_value ||= attribute
 
           msg = SomeMessage.new
-          msg.some_attribute = attribute
+          msg.some_attribute = attribute_value
           msg
         end
 

--- a/lib/event_store/entity_projection/entity_projection.rb
+++ b/lib/event_store/entity_projection/entity_projection.rb
@@ -66,18 +66,18 @@ module EventStore
     end
 
     module Build
-      def build(entity, stream_name, starting_position: nil, slice_size: nil, session: nil)
+      def build(entity, stream_name, starting_position: nil, slice_size: nil, session: nil, version: nil)
         new(entity).tap do |instance|
           dispatcher = instance
-          EventStore::Messaging::Reader.configure instance, stream_name, dispatcher, starting_position: starting_position, slice_size: slice_size, session: session
+          EventStore::Messaging::Reader.configure instance, stream_name, dispatcher, starting_position: starting_position, slice_size: slice_size, session: session, ending_position: version
           Telemetry::Logger.configure instance
         end
       end
     end
 
     module Actuate
-      def call(entity, stream_name, starting_position: nil, slice_size: nil, session: nil)
-        instance = build entity, stream_name, starting_position: starting_position, slice_size: slice_size, session: session
+      def call(entity, stream_name, starting_position: nil, slice_size: nil, session: nil, version: nil)
+        instance = build entity, stream_name, starting_position: starting_position, slice_size: slice_size, session: session, version: version
         instance.()
       end
       alias :! :call # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]

--- a/lib/event_store/entity_projection/entity_projection.rb
+++ b/lib/event_store/entity_projection/entity_projection.rb
@@ -66,18 +66,18 @@ module EventStore
     end
 
     module Build
-      def build(entity, stream_name, starting_position: nil, slice_size: nil, session: nil, version: nil)
+      def build(entity, stream_name, starting_position: nil, ending_position: nil, slice_size: nil, session: nil)
         new(entity).tap do |instance|
           dispatcher = instance
-          EventStore::Messaging::Reader.configure instance, stream_name, dispatcher, starting_position: starting_position, slice_size: slice_size, session: session, ending_position: version
+          EventStore::Messaging::Reader.configure instance, stream_name, dispatcher, starting_position: starting_position, ending_position: ending_position, slice_size: slice_size, session: session
           Telemetry::Logger.configure instance
         end
       end
     end
 
     module Actuate
-      def call(entity, stream_name, starting_position: nil, slice_size: nil, session: nil, version: nil)
-        instance = build entity, stream_name, starting_position: starting_position, slice_size: slice_size, session: session, version: version
+      def call(entity, stream_name, starting_position: nil, ending_position: nil, slice_size: nil, session: nil)
+        instance = build entity, stream_name, starting_position: starting_position, ending_position: ending_position, slice_size: slice_size, session: session
         instance.()
       end
       alias :! :call # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]

--- a/lib/event_store/entity_projection/entity_projection.rb
+++ b/lib/event_store/entity_projection/entity_projection.rb
@@ -1,18 +1,21 @@
 module EventStore
   module EntityProjection
     def self.included(cls)
-      cls.extend Logger
-      cls.extend Build
-      cls.extend Actuate
-      cls.extend ApplyMacro
-      cls.extend EntityNameMacro
-      cls.extend Info
-      cls.extend EventStore::Messaging::Dispatcher::MessageRegistry
-      cls.extend EventStore::Messaging::Dispatcher::BuildMessage
+      cls.class_exec do
+        extend Logger
+        extend Build
+        extend Actuate
+        extend ApplyMacro
+        extend EntityNameMacro
+        extend Info
+        extend EventStore::Messaging::Dispatcher::MessageRegistry
+        extend EventStore::Messaging::Dispatcher::BuildMessage
 
-      cls.send :attr_reader, :entity
-      cls.send :dependency, :reader, EventStore::Messaging::Reader
-      cls.send :dependency, :logger, Telemetry::Logger
+        attr_reader :entity
+
+        dependency :reader, EventStore::Messaging::Reader
+        dependency :logger, Telemetry::Logger
+      end
     end
 
     module Logger

--- a/test/bench/project_specific_version_of_entity.rb
+++ b/test/bench/project_specific_version_of_entity.rb
@@ -1,0 +1,23 @@
+require_relative './bench_init'
+
+context "Projecting a Specific Version of an Entity" do
+  stream_name = EventStore::EntityProjection::Controls::StreamName.get 'testProjectSpecificVersion'
+
+  message_0 = EventStore::EntityProjection::Controls::Message.example 'value-of-version-0'
+  message_1 = EventStore::EntityProjection::Controls::Message.example 'value-of-version-1'
+
+  EventStore::EntityProjection::Controls::Writer.write message_0, stream_name
+  EventStore::EntityProjection::Controls::Writer.write message_1, stream_name
+
+  entity = EventStore::EntityProjection::Controls::Entity.example
+
+  last_event_number = EventStore::EntityProjection::Controls::EntityProjection::SomeProjection.(entity, stream_name, version: 0)
+
+  test "Last version considered matches specified version" do
+    assert last_event_number == 0
+  end
+
+  test "Messages written after specified version are not applied" do
+    assert entity.some_attribute == 'value-of-version-0'
+  end
+end

--- a/test/bench/project_specific_version_of_entity.rb
+++ b/test/bench/project_specific_version_of_entity.rb
@@ -11,7 +11,7 @@ context "Projecting a Specific Version of an Entity" do
 
   entity = EventStore::EntityProjection::Controls::Entity.example
 
-  last_event_number = EventStore::EntityProjection::Controls::EntityProjection::SomeProjection.(entity, stream_name, version: 0)
+  last_event_number = EventStore::EntityProjection::Controls::EntityProjection::SomeProjection.(entity, stream_name, ending_position: 0)
 
   test "Last version considered matches specified version" do
     assert last_event_number == 0


### PR DESCRIPTION
Depends on https://github.com/eventide-project/event-store-messaging/pull/2

Enables projections to only project an entity up to a particular version.